### PR TITLE
Remove Windows builds.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -119,6 +119,8 @@ jobs:
         shell: bash
         run: |
           make build
+        if: matrix.os != 'windows-latest' # Remove windows builds. Difficult to maintain.
+
       - name: Cross-compile
         shell: bash
         run: |
@@ -131,7 +133,8 @@ jobs:
           if-no-files-found: error
           name: build-${{ matrix.job_name }}
           path: bin/*
-
+        if: matrix.os != 'windows-latest' # Remove windows builds. Difficult to maintain.
+        
       - name: Release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
There are windows-related bugs on every release. Difficult to maintain.

Signed-off-by: Antonio Navarro Perez <antnavper@gmail.com>