### PR TITLE
Whitespace: replace tabs with spaces in config_template.yaml.

### DIFF
--- a/templates/config_template.yaml
+++ b/templates/config_template.yaml
@@ -55,19 +55,19 @@ log:
   path: ./distribyted-data/logs
 
   # MaxBackups is the maximum number of old log files to retain.  The default
-	# is to retain all old log files (though MaxAge may still cause them to get
-	# deleted.)
+  # is to retain all old log files (though MaxAge may still cause them to get
+  # deleted.)
   max_backups: 2
 
   # MaxAge is the maximum number of days to retain old log files based on the
-	# timestamp encoded in their filename.  Note that a day is defined as 24
-	# hours and may not exactly correspond to calendar days due to daylight
-	# savings, leap seconds, etc. The default is not to remove old log files
-	# based on age.
+  # timestamp encoded in their filename.  Note that a day is defined as 24
+  # hours and may not exactly correspond to calendar days due to daylight
+  # savings, leap seconds, etc. The default is not to remove old log files
+  # based on age.
   # max_age: 30
 
   # MaxSize is the maximum size in megabytes of the log file before it gets
-	# rotated. It defaults to 100 megabytes.
+  # rotated. It defaults to 100 megabytes.
   max_size: 50
 
   # debug: true


### PR DESCRIPTION
Some lines in the config template were using tabs instead of spaces for indentation.
Making it all the same.