### PR TITLE
Expose "disable TCP/uTP" torrent client options.

### DIFF
--- a/config/model.go
+++ b/config/model.go
@@ -27,6 +27,8 @@ type TorrentGlobal struct {
 	GlobalCacheSize        int64  `yaml:"global_cache_size,omitempty"`
 	MetadataFolder         string `yaml:"metadata_folder,omitempty"`
 	DisableIPv6            bool   `yaml:"disable_ipv6,omitempty"`
+	DisableTCP             bool   `yaml:"disable_tcp,omitempty"`
+	DisableUTP             bool   `yaml:"disable_utp,omitempty"`
 	IP                     string `yaml:"ip,omitempty"`
 }
 

--- a/templates/config_template.yaml
+++ b/templates/config_template.yaml
@@ -29,6 +29,12 @@ torrent:
   # Disable IPv6.
   #disable_ipv6: true
 
+  # Disable TCP.
+  #disable_tcp: false
+
+  # Disable uTP.
+  #disable_utp: false
+
   # Do not stop distribyted if some of the torrents are not able to load the info correctly on startup.
   continue_when_add_timeout: false
 

--- a/torrent/client.go
+++ b/torrent/client.go
@@ -23,6 +23,8 @@ func NewClient(st storage.ClientImpl, fis bep44.Store, cfg *config.TorrentGlobal
 	torrentCfg.PeerID = string(id[:])
 	torrentCfg.DefaultStorage = st
 	torrentCfg.DisableIPv6 = cfg.DisableIPv6
+	torrentCfg.DisableTCP = cfg.DisableTCP
+	torrentCfg.DisableUTP = cfg.DisableUTP
 
 	if cfg.IP != "" {
 		ip := net.ParseIP(cfg.IP)


### PR DESCRIPTION
Specifically, disabling TCP in favor of uTP (UDP-based) helps reduce network congestion.