### PR TITLE
feat: Avoid timeout errors on start.

### DIFF
--- a/cmd/distribyted/main.go
+++ b/cmd/distribyted/main.go
@@ -12,11 +12,11 @@ import (
 
 	"github.com/anacrolix/missinggo/v2/filecache"
 	"github.com/anacrolix/torrent/storage"
-	"github.com/distribyted/distribyted/config"
-	"github.com/distribyted/distribyted/fs"
 	"github.com/rs/zerolog/log"
 	"github.com/urfave/cli/v2"
 
+	"github.com/distribyted/distribyted/config"
+	"github.com/distribyted/distribyted/fs"
 	"github.com/distribyted/distribyted/fuse"
 	"github.com/distribyted/distribyted/http"
 	dlog "github.com/distribyted/distribyted/log"
@@ -154,7 +154,11 @@ func load(configPath string, port, webDAVPort int, fuseAllowOther bool) error {
 		return fmt.Errorf("error starting magnet database: %w", err)
 	}
 
-	ts := torrent.NewService([]loader.Loader{cl, fl}, dbl, ss, c, conf.Torrent.AddTimeout, conf.Torrent.ReadTimeout)
+	ts := torrent.NewService([]loader.Loader{cl, fl}, dbl, ss, c,
+		conf.Torrent.AddTimeout,
+		conf.Torrent.ReadTimeout,
+		conf.Torrent.ContinueWhenAddTimeout,
+	)
 
 	var mh *fuse.Handler
 	if conf.Fuse != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -28,10 +28,11 @@ func DefaultConfig() *Root {
 			Pass: "admin",
 		},
 		Torrent: &TorrentGlobal{
-			GlobalCacheSize: 2048,
-			MetadataFolder:  metadataFolder,
-			AddTimeout:      60,
-			ReadTimeout:     120,
+			GlobalCacheSize:        2048,
+			MetadataFolder:         metadataFolder,
+			AddTimeout:             60,
+			ReadTimeout:            120,
+			ContinueWhenAddTimeout: false,
 		},
 		Fuse: &FuseGlobal{
 			AllowOther: false,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,7 +1,7 @@
 package config
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 	"testing"
 
@@ -16,7 +16,7 @@ func TestTemplateConfig(t *testing.T) {
 	f, err := os.Open("../templates/config_template.yaml")
 	require.NoError(err)
 
-	b, err := ioutil.ReadAll(f)
+	b, err := io.ReadAll(f)
 	require.NoError(err)
 
 	conf := &Root{}

--- a/config/model.go
+++ b/config/model.go
@@ -21,12 +21,13 @@ type Log struct {
 }
 
 type TorrentGlobal struct {
-	ReadTimeout     int    `yaml:"read_timeout,omitempty"`
-	AddTimeout      int    `yaml:"add_timeout,omitempty"`
-	GlobalCacheSize int64  `yaml:"global_cache_size,omitempty"`
-	MetadataFolder  string `yaml:"metadata_folder,omitempty"`
-	DisableIPv6     bool   `yaml:"disable_ipv6,omitempty"`
-	IP              string `yaml:"ip,omitempty"`
+	ReadTimeout            int    `yaml:"read_timeout,omitempty"`
+	ContinueWhenAddTimeout bool   `yaml:"continue_when_add_timeout,omitempty"`
+	AddTimeout             int    `yaml:"add_timeout,omitempty"`
+	GlobalCacheSize        int64  `yaml:"global_cache_size,omitempty"`
+	MetadataFolder         string `yaml:"metadata_folder,omitempty"`
+	DisableIPv6            bool   `yaml:"disable_ipv6,omitempty"`
+	IP                     string `yaml:"ip,omitempty"`
 }
 
 type WebDAVGlobal struct {

--- a/templates/config_template.yaml
+++ b/templates/config_template.yaml
@@ -29,6 +29,9 @@ torrent:
   # Disable IPv6.
   #disable_ipv6: true
 
+  # Do not stop distribyted if some of the torrents are not able to load the info correctly on startup.
+  continue_when_add_timeout: false
+
   # Timeout in seconds when adding a magnet or a torrent.
   add_timeout: 60
 


### PR DESCRIPTION
Add a flag to prevent the node to fail if some torrent is not able to load metadata.

Closes #247 